### PR TITLE
workaround proposed in github.com/antonleykin/M2/pull/5#issuecomment-540004899

### DIFF
--- a/M2/include/M2/gc-include.h
+++ b/M2/include/M2/gc-include.h
@@ -37,6 +37,7 @@
   #include <gc/gc.h>
 
   #if defined(__cplusplus)
+    #define GC_NEW_ABORTS_ON_OOM
     #include <gc/gc_cpp.h>
   #endif
 #endif


### PR DESCRIPTION
extract the implementation of GC_throw_bad_alloc() from
https://github.com/ivmai/bdwgc/blob/master/gc_cpp.cc (just erase all the
new/delete functions there) and use the result instead of libgccpp