### PR TITLE
add  --enable-static to DEBUG options for GC

### DIFF
--- a/M2/libraries/gc/Makefile.in
+++ b/M2/libraries/gc/Makefile.in
@@ -59,7 +59,7 @@ CONFIGOPTIONS += --disable-shared
 endif
 
 ifeq (@DEBUG@,yes)
-CONFIGOPTIONS += --enable-gc-debug
+CONFIGOPTIONS += --enable-gc-debug  --enable-static
 CPPFLAGS += -DDBG_HDRS_ALL=1 -DGC_ABORT_ON_LEAK=1
 
 #   "--enable-gc-assertions" causes all the tests to fail on 64 bit mac os x


### PR DESCRIPTION
to make sure that GC_check_annotated_obj is exported to libgc,
otherwise one gets linking errors if M2 is configured with --enable-debug