### PR TITLE
mpfi implementation - in progress.

### DIFF
--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -12,21 +12,21 @@ export (lhs:Expr) + (rhs:Expr) : Expr := (
      when lhs
      is x:ZZcell do (
 	  when rhs
-	  is y:ZZcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, ZZ, ZZ, ZZ
+	      is y:ZZcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, ZZ, ZZ, ZZ
      	  is y:QQcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, ZZ, QQ, QQ
      	  is y:RRcell do toExpr(y.v + x.v)			    -- # typical value: symbol +, ZZ, RR, RR
-	  is y:RRicell do toExpr(y.v + x.v)
+          is y:RRicell do toExpr(y.v + x.v)
      	  is y:CCcell do toExpr(toRR(x.v,precision(y.v.re)) + y.v)	    -- # typical value: symbol +, ZZ, CC, CC
-	  is Error do rhs
-	  else binarymethod(lhs,rhs,PlusS))
+	      is Error do rhs
+	      else binarymethod(lhs,rhs,PlusS))
      is x:QQcell do (
 	  when rhs
-	  is y:ZZcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, QQ, ZZ, QQ
+	      is y:ZZcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, QQ, ZZ, QQ
      	  is y:QQcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, QQ, QQ, QQ
      	  is y:RRcell do toExpr(y.v + x.v)			    -- # typical value: symbol +, QQ, RR, RR
-	  is y:RRicell do toExpr(y.v + x.v)
+	      is y:RRicell do toExpr(y.v + x.v)
      	  is y:CCcell do toExpr(toRR(x.v,precision(y.v.re)) + y.v)	    -- # typical value: symbol +, QQ, CC, CC
-	  is Error do rhs
+	      is Error do rhs
 	  else binarymethod(lhs,rhs,PlusS))
      is x:RawRingElementCell do (
 	  when rhs
@@ -39,21 +39,21 @@ export (lhs:Expr) + (rhs:Expr) : Expr := (
 	  else binarymethod(lhs,rhs,PlusS))
      is x:RRcell do (
 	  when rhs
-	  is y:ZZcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, RR, ZZ, RR
+	      is y:ZZcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, RR, ZZ, RR
      	  is y:QQcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, RR, QQ, RR
      	  is y:RRcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, RR, RR, RR
-	  is y:RRicell do toExpr(y.v + x.v)
+	      is y:RRicell do toExpr(y.v + x.v)
      	  is y:CCcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, RR, CC, CC
-	  is Error do rhs
-	  else binarymethod(lhs,rhs,PlusS))
+	      is Error do rhs
+	      else binarymethod(lhs,rhs,PlusS))
      is x:RRicell do (
-        when rhs is y:RRicell do toExpr(x.v + y.v) -- # typical value: symbol +, RRi, RRi, RRi
+        when rhs
 	     is y:ZZcell do toExpr(x.v + y.v)
 	     is y:QQcell do toExpr(x.v + y.v)
 	     is y:RRcell do toExpr(x.v + y.v)
+         is y:RRicell do toExpr(x.v + y.v)
 	     is Error do rhs
-	     else buildErrorPacket(EngineError("addition not implemented"))
-                      )
+	     else buildErrorPacket(EngineError("addition not implemented")))
      is x:CCcell do (
 	  when rhs
 	  is y:ZZcell do toExpr(x.v + toRR(y.v,precision(x.v.re)))	    -- # typical value: symbol +, CC, ZZ, CC
@@ -100,6 +100,7 @@ plusfun1(rhs:Code):Expr := (
      is Error do r
      is ZZcell do r						    -- # typical value: symbol +, ZZ, ZZ
      is RRcell do r						    -- # typical value: symbol +, RR, RR
+     is RRicell do r
      is CCcell do r						    -- # typical value: symbol +, CC, CC
      is QQcell do r						    -- # typical value: symbol +, QQ, QQ
      is RawRingElementCell do r				    -- # typical value: symbol +, RawRingElement, RawRingElement
@@ -117,7 +118,8 @@ setup(PlusS,plusfun1,plusfun);
 export - (rhs:Expr) : Expr := (
      when rhs
      is x:ZZcell do toExpr(-x.v)				    -- # typical value: symbol -, ZZ, ZZ                            
-     is x:RRcell do toExpr(-x.v)				    -- # typical value: symbol -, RR, RR                            
+     is x:RRcell do toExpr(-x.v)				    -- # typical value: symbol -, RR, RR
+     is x:RRicell do toExpr(-x.v)
      is x:CCcell do toExpr(-x.v)				    -- # typical value: symbol -, CC, CC                            
      is x:QQcell do toExpr(-x.v)				    -- # typical value: symbol -, QQ, QQ                            
      is x:RawRingElementCell do toExpr(-x.p)			    -- # typical value: symbol -, RawRingElement, RawRingElement    
@@ -137,23 +139,25 @@ export (lhs:Expr) - (rhs:Expr) : Expr := (
      when lhs
      is x:ZZcell do (
 	  when rhs
-	  is y:ZZcell do toExpr(x.v - y.v)			    -- # typical value: symbol -, ZZ, ZZ, ZZ
+	      is y:ZZcell do toExpr(x.v - y.v)			    -- # typical value: symbol -, ZZ, ZZ, ZZ
      	  is y:QQcell do toExpr(x.v - y.v)			    -- # typical value: symbol -, ZZ, QQ, QQ
-	  is y:RRcell do toExpr(toRR(x.v,precision(y.v)) - y.v)		    -- # typical value: symbol -, ZZ, RR, RR
-	  is y:CCcell do toExpr(toRR(x.v,precision(y.v.re)) - y.v)	    -- # typical value: symbol -, ZZ, CC, CC
-	  is Error do rhs
-	  else binarymethod(lhs,rhs,MinusS))
+	      is y:RRcell do toExpr(toRR(x.v,precision(y.v)) - y.v)		    -- # typical value: symbol -, ZZ, RR, RR
+          is y:RRicell do toExpr(toRRi(x.v,precision(y.v)) - y.v)
+	      is y:CCcell do toExpr(toRR(x.v,precision(y.v.re)) - y.v)	    -- # typical value: symbol -, ZZ, CC, CC
+	      is Error do rhs
+	      else binarymethod(lhs,rhs,MinusS))
      is x:QQcell do (
-	  when rhs
-	  is y:ZZcell do toExpr(x.v - y.v)			    -- # typical value: symbol -, QQ, ZZ, QQ
+      when rhs
+	      is y:ZZcell do toExpr(x.v - y.v)			    -- # typical value: symbol -, QQ, ZZ, QQ
      	  is y:QQcell do toExpr(x.v - y.v)			    -- # typical value: symbol -, QQ, QQ, QQ
-	  is y:RRcell do toExpr(toRR(x.v,precision(y.v)) - y.v)		    -- # typical value: symbol -, QQ, RR, RR
-	  is y:CCcell do toExpr(toRR(x.v,precision(y.v.re)) - y.v)	    -- # typical value: symbol -, QQ, CC, CC
-	  is Error do rhs
-	  else binarymethod(lhs,rhs,MinusS))
+	      is y:RRcell do toExpr(toRR(x.v,precision(y.v)) - y.v)		    -- # typical value: symbol -, QQ, RR, RR
+          is y:RRicell do toExpr(toRRi(x.v,precision(y.v)) - y.v)
+	      is y:CCcell do toExpr(toRR(x.v,precision(y.v.re)) - y.v)	    -- # typical value: symbol -, QQ, CC, CC
+	      is Error do rhs
+	      else binarymethod(lhs,rhs,MinusS))
      is x:RawRingElementCell do (
 	  when rhs
-	  is y:RawRingElementCell do (			    -- # typical value: symbol -, RawRingElement, RawRingElement, RawRingElement
+	      is y:RawRingElementCell do (			    -- # typical value: symbol -, RawRingElement, RawRingElement, RawRingElement
 	       when x.p-y.p
 	       is t:RawRingElement do toExpr(t)
 	       is null do buildErrorPacket(EngineError("polynomial subtraction failed"))
@@ -165,9 +169,18 @@ export (lhs:Expr) - (rhs:Expr) : Expr := (
 	  is y:ZZcell do toExpr(x.v - y.v)			    -- # typical value: symbol -, RR, ZZ, RR
      	  is y:QQcell do toExpr(x.v - y.v)			    -- # typical value: symbol -, RR, QQ, RR
 	  is y:RRcell do toExpr(x.v - y.v)			    -- # typical value: symbol -, RR, RR, RR
+      is y:RRicell do toExpr(toRRi(x.v) - y.v)
 	  is y:CCcell do toExpr(x.v - y.v)			    -- # typical value: symbol -, RR, CC, CC
 	  is Error do rhs
 	  else binarymethod(lhs,rhs,MinusS))
+    is x:RRicell do (
+      when rhs
+	       is y:ZZcell do toExpr(x.v - y.v)
+	       is y:QQcell do toExpr(x.v - y.v)
+	       is y:RRcell do toExpr(x.v - y.v)
+           is y:RRicell do toExpr(x.v - y.v) -- # typical value: symbol +, RRi, RRi, RRi
+	       is Error do rhs
+	       else buildErrorPacket(EngineError("subtration not implemented")))
      is x:CCcell do (
 	  when rhs
 	  is y:ZZcell do toExpr(x.v - toRR(y.v,precision(x.v.re)))	    -- # typical value: symbol -, CC, ZZ, CC

--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -15,6 +15,7 @@ export (lhs:Expr) + (rhs:Expr) : Expr := (
 	  is y:ZZcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, ZZ, ZZ, ZZ
      	  is y:QQcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, ZZ, QQ, QQ
      	  is y:RRcell do toExpr(y.v + x.v)			    -- # typical value: symbol +, ZZ, RR, RR
+	  is y:RRicell do toExpr(y.v + x.v)
      	  is y:CCcell do toExpr(toRR(x.v,precision(y.v.re)) + y.v)	    -- # typical value: symbol +, ZZ, CC, CC
 	  is Error do rhs
 	  else binarymethod(lhs,rhs,PlusS))
@@ -23,6 +24,7 @@ export (lhs:Expr) + (rhs:Expr) : Expr := (
 	  is y:ZZcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, QQ, ZZ, QQ
      	  is y:QQcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, QQ, QQ, QQ
      	  is y:RRcell do toExpr(y.v + x.v)			    -- # typical value: symbol +, QQ, RR, RR
+	  is y:RRicell do toExpr(y.v + x.v)
      	  is y:CCcell do toExpr(toRR(x.v,precision(y.v.re)) + y.v)	    -- # typical value: symbol +, QQ, CC, CC
 	  is Error do rhs
 	  else binarymethod(lhs,rhs,PlusS))
@@ -40,12 +42,17 @@ export (lhs:Expr) + (rhs:Expr) : Expr := (
 	  is y:ZZcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, RR, ZZ, RR
      	  is y:QQcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, RR, QQ, RR
      	  is y:RRcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, RR, RR, RR
+	  is y:RRicell do toExpr(y.v + x.v)
      	  is y:CCcell do toExpr(x.v + y.v)			    -- # typical value: symbol +, RR, CC, CC
 	  is Error do rhs
 	  else binarymethod(lhs,rhs,PlusS))
      is x:RRicell do (
         when rhs is y:RRicell do toExpr(x.v + y.v) -- # typical value: symbol +, RRi, RRi, RRi
-                 else buildErrorPacket(EngineError("Failed to create sum"))
+	     is y:ZZcell do toExpr(x.v + y.v)
+	     is y:QQcell do toExpr(x.v + y.v)
+	     is y:RRcell do toExpr(x.v + y.v)
+	     is Error do rhs
+	     else buildErrorPacket(EngineError("addition not implemented"))
                       )
      is x:CCcell do (
 	  when rhs

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1361,6 +1361,7 @@ toRRi(e:Expr):Expr := (
      when e
      is x:ZZcell do toExpr(toRRi(x.v,defaultPrecision))
      is x:QQcell do toExpr(toRRi(x.v,defaultPrecision))
+     is x:RRcell do toExpr(toRRi(x.v,defaultPrecision))
      is RRicell do e
      is s:Sequence do (
 	  if length(s) != 2 then WrongNumArgs(1,2) else
@@ -1370,6 +1371,7 @@ toRRi(e:Expr):Expr := (
 	       	    when s.1
      	       	    is x:ZZcell do toExpr(toRRi(x.v,toULong(prec.v)))
 	       	    is x:QQcell do toExpr(toRRi(x.v,toULong(prec.v)))
+		    is x:RRcell do toExpr(toRRi(x.v,toULong(prec.v)))
      	       	    is x:RRicell do toExpr(toRRi(x.v,toULong(prec.v)))
 		    else WrongArg(1,"an integral, rational, or real number")
 		    )
@@ -1380,12 +1382,29 @@ toRRi(e:Expr):Expr := (
 setupfun("toRRi",toRRi);
                                                      
 interval(e:Expr):Expr := (
-    when e is s:Sequence do (
-            when s.0 is x:ZZcell do (
-                    when s.1 is y:ZZcell do (toExpr(interval(x.v,y.v)))
-                    else WrongArg("not implemented yet"))
-            else WrongArg("not implemented yet"))
-    else WrongArg("not implemented yet"));
+    when e
+    	 is x:ZZcell do toExpr(toRRi(x.v,defaultPrecision))
+	 is x:QQcell do toExpr(toRRi(x.v,defaultPrecision))
+	 is x:RRcell do toExpr(toRRi(x.v,defaultPrecision))
+	 is x:RRicell do e
+    	 is s:Sequence do (
+	    if length(s) > 3 then WrongNumArgs(1,3) else
+	    if length(s) == 2 then (
+               when s.0 is x:ZZcell do (
+               	    when s.1 is y:ZZcell do (toExpr(interval(x.v,y.v))) -- Add precision versions
+		    	 is y:QQcell do (toExpr(interval(x.v,y.v)))
+			 is y:RRcell do (toExpr(interval(x.v,y.v)))
+                    	 else WrongArg(1,"a pair of integral, rational, or real numbers"))
+	       else WrongArg("not implemented yet"))
+	    else when s.0 is prec:ZZcell do (
+	       when s.1 is x:ZZcell do (
+                    when s.2 is y:ZZcell do (toExpr(interval(x.v,y.v,toULong(prec.v)))) -- Add precision versions
+		    	 is y:QQcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
+			 is y:RRcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
+                    	 else WrongArg(1,"a pair of integral, rational, or real numbers"))
+	       else WrongArg(1,"a pair of integral, rational, or real numbers"))
+	    else WrongArg(1,"a pair or triple  of integral, rational, or real numbers"))
+   	 else WrongArg("not implemented yet"));
 setupfun("interval",interval);
 
 toCC(e:Expr):Expr := (

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1391,14 +1391,34 @@ interval(e:Expr):Expr := (
 	    if length(s) > 3 then WrongNumArgs(1,3) else
 	    if length(s) == 2 then (
                when s.0 is x:ZZcell do (
-               	    when s.1 is y:ZZcell do (toExpr(interval(x.v,y.v))) -- Add precision versions
+               	    when s.1 is y:ZZcell do (toExpr(interval(x.v,y.v)))
+		    	 is y:QQcell do (toExpr(interval(x.v,y.v)))
+			 is y:RRcell do (toExpr(interval(x.v,y.v)))
+                    	 else WrongArg(1,"a pair of integral, rational, or real numbers"))
+	       is x:QQcell do (
+	       	    when s.1 is y:ZZcell do (toExpr(interval(x.v,y.v)))
+		    	 is y:QQcell do (toExpr(interval(x.v,y.v)))
+			 is y:RRcell do (toExpr(interval(x.v,y.v)))
+                    	 else WrongArg(1,"a pair of integral, rational, or real numbers"))
+	       is x:RRcell do (
+	       	    when s.1 is y:ZZcell do (toExpr(interval(x.v,y.v)))
 		    	 is y:QQcell do (toExpr(interval(x.v,y.v)))
 			 is y:RRcell do (toExpr(interval(x.v,y.v)))
                     	 else WrongArg(1,"a pair of integral, rational, or real numbers"))
 	       else WrongArg("not implemented yet"))
 	    else when s.0 is prec:ZZcell do (
 	       when s.1 is x:ZZcell do (
-                    when s.2 is y:ZZcell do (toExpr(interval(x.v,y.v,toULong(prec.v)))) -- Add precision versions
+                    when s.2 is y:ZZcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
+		    	 is y:QQcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
+			 is y:RRcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
+                    	 else WrongArg(1,"a pair of integral, rational, or real numbers"))
+		 is x:QQcell do (
+		    when s.2 is y:ZZcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
+		    	 is y:QQcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
+			 is y:RRcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
+                    	 else WrongArg(1,"a pair of integral, rational, or real numbers"))
+		is x:RRcell do (
+		    when s.2 is y:ZZcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
 		    	 is y:QQcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
 			 is y:RRcell do (toExpr(interval(x.v,y.v,toULong(prec.v))))
                     	 else WrongArg(1,"a pair of integral, rational, or real numbers"))

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -1238,7 +1238,7 @@ export (x:RRi) + (y:QQ) : RRi := (
      moveToRRiandclear(z));
 
 export (x:RRi) + (y:RR) : RRi := (
-     z := newRRimutable(precision0(x));
+     z := newRRimutable(min(precision0(x),precision0(y)));
      Ccode( void, "mpfi_add_fr(", z, ",",  x, ",",  y, ")" );
      moveToRRiandclear(z));
 
@@ -1250,13 +1250,17 @@ export - (y:RR) : RR := (
 export - (y:RRi) : RRi := (
     z := newRRimutable(precision0(y));
     Ccode( void, "mpfi_neg(", z, ",",  y, ")" );
-    -- Behavior might be different for mpfi and removed an argument.
     moveToRRiandclear(z));
 
 export (x:RR) - (y:RR) : RR := (
      z := newRRmutable(min(precision0(x),precision0(y)));
      Ccode( void, "mpfr_sub(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
      moveToRRandclear(z));
+                                    
+export (x:RRi) - (y:RRi) : RRi := (
+     z := newRRimutable(min(precision0(x),precision0(y)));
+     Ccode( void, "mpfi_sub(", z, ",",  x, ",",  y, ")" );
+     moveToRRiandclear(z));
 
 export (x:RR) - (y:int) : RR := (
      z := newRRmutable(precision0(x));
@@ -1264,16 +1268,38 @@ export (x:RR) - (y:int) : RR := (
      moveToRRandclear(z));
 
 export (y:int) - (x:RR) : RR := -(x-y);
-     
+  
+export (x:RRi) - (y:int) : RRi := (
+     z := newRRimutable(precision0(x));
+     Ccode( void, "mpfi_sub_si(", z, ",",  x, ",",  y, ")" );
+     moveToRRiandclear(z));
+                                    
+export (y:int) - (x:RRi) : RRi := -(x-y);
+                                    
 export (x:RR) - (y:ZZ) : RR := (
      z := newRRmutable(precision0(x));
      Ccode( void, "mpfr_sub_z(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
      moveToRRandclear(z));
+                                    
+export (x:RRi) - (y:ZZ) : RRi := (
+     z := newRRimutable(precision0(x));
+     Ccode( void, "mpfi_sub_z(", z, ",",  x, ",",  y, ")" );
+     moveToRRiandclear(z));
      
 export (x:RR) - (y:QQ) : RR := (
      z := newRRmutable(precision0(x));
      Ccode( void, "mpfr_sub_q(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
      moveToRRandclear(z));
+                                    
+export (x:RRi) - (y:QQ) : RRi := (
+     z := newRRimutable(precision0(x));
+     Ccode( void, "mpfi_sub_q(", z, ",",  x, ",",  y, ")" );
+     moveToRRiandclear(z));
+                                    
+export (x:RRi) - (y:RR) : RRi := (
+     z := newRRimutable(min(precision0(x),precision0(y)));
+     Ccode( void, "mpfi_sub_fr(", z, ",",  x, ",",  y, ")" );
+     moveToRRiandclear(z));
 
 export abs(x:RR) : RR := if isNegative0(x) then -x else x;
 

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -908,14 +908,37 @@ export toRRi(n:double,prec:ulong):RRi := (
 export toRR(n:double):RR := toRR(n,defaultPrecision);
 
 export toRRi(n:double):RRi := toRRi(n,defaultPrecision);
+
+export toRRi(n:RR,prec:ulong):RRi := (
+       x := newRRimutable(prec);
+       Ccode(void, "mpfi_set_fr(", x, ",", n, ")" );
+       moveToRRiandclear(x));
+
+export toRRi(n:RR):RRi := toRRi(n,defaultPrecision);
                                     
 export interval(a:ZZ,b:ZZ,prec:ulong):RRi := (
      x := newRRimutable(prec);
      Ccode( void, "mpfr_set_z( &", x, "->left," , a, ",GMP_RNDD)");
      Ccode( void, "mpfr_set_z( &", x, "->right," , b, ",GMP_RNDU)");
      moveToRRiandclear(x));
-                                    
+                                  
 export interval(a:ZZ,b:ZZ):RRi := interval(a,b,defaultPrecision);
+
+export interval(a:ZZ,b:QQ,prec:ulong):RRi := (
+     x := newRRimutable(prec);
+     Ccode( void, "mpfr_set_z( &", x, "->left," , a, ",GMP_RNDD)");
+     Ccode( void, "mpfr_set_q( &", x, "->right," , b, ",GMP_RNDU)");
+     moveToRRiandclear(x));
+
+export interval(a:ZZ, b:QQ):RRi := interval(a,b,defaultPrecision);
+
+export interval(a:ZZ,b:RR,prec:ulong):RRi := (
+     x := newRRimutable(prec);
+     Ccode( void, "mpfr_set_z( &", x, "->left," , a, ",GMP_RNDD)");
+     Ccode( void, "mpfr_set( &", x, "->right," , b, ",GMP_RNDU)");
+     moveToRRiandclear(x));
+
+export interval(a:ZZ, b:RR):RRi := interval(a,b,defaultPrecision);
                                               
 export infinityRR(prec:ulong,sign:int):RR := (
      x := newRRmutable(prec);

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -939,7 +939,55 @@ export interval(a:ZZ,b:RR,prec:ulong):RRi := (
      moveToRRiandclear(x));
 
 export interval(a:ZZ, b:RR):RRi := interval(a,b,defaultPrecision);
-                                              
+
+export interval(a:QQ,b:ZZ,prec:ulong):RRi := (
+     x := newRRimutable(prec);
+     Ccode( void, "mpfr_set_q( &", x, "->left," , a, ",GMP_RNDD)");
+     Ccode( void, "mpfr_set_z( &", x, "->right," , b, ",GMP_RNDU)");
+     moveToRRiandclear(x));
+                                  
+export interval(a:QQ,b:ZZ):RRi := interval(a,b,defaultPrecision);
+
+export interval(a:QQ,b:QQ,prec:ulong):RRi := (
+     x := newRRimutable(prec);
+     Ccode( void, "mpfr_set_q( &", x, "->left," , a, ",GMP_RNDD)");
+     Ccode( void, "mpfr_set_q( &", x, "->right," , b, ",GMP_RNDU)");
+     moveToRRiandclear(x));
+
+export interval(a:QQ, b:QQ):RRi := interval(a,b,defaultPrecision);
+
+export interval(a:QQ,b:RR,prec:ulong):RRi := (
+     x := newRRimutable(prec);
+     Ccode( void, "mpfr_set_q( &", x, "->left," , a, ",GMP_RNDD)");
+     Ccode( void, "mpfr_set( &", x, "->right," , b, ",GMP_RNDU)");
+     moveToRRiandclear(x));
+
+export interval(a:QQ, b:RR):RRi := interval(a,b,defaultPrecision);
+
+export interval(a:RR,b:ZZ,prec:ulong):RRi := (
+     x := newRRimutable(prec);
+     Ccode( void, "mpfr_set( &", x, "->left," , a, ",GMP_RNDD)");
+     Ccode( void, "mpfr_set_z( &", x, "->right," , b, ",GMP_RNDU)");
+     moveToRRiandclear(x));
+                                  
+export interval(a:RR,b:ZZ):RRi := interval(a,b,defaultPrecision);
+
+export interval(a:RR,b:QQ,prec:ulong):RRi := (
+     x := newRRimutable(prec);
+     Ccode( void, "mpfr_set( &", x, "->left," , a, ",GMP_RNDD)");
+     Ccode( void, "mpfr_set_q( &", x, "->right," , b, ",GMP_RNDU)");
+     moveToRRiandclear(x));
+
+export interval(a:RR, b:QQ):RRi := interval(a,b,defaultPrecision);
+
+export interval(a:RR,b:RR,prec:ulong):RRi := (
+     x := newRRimutable(prec);
+     Ccode( void, "mpfr_set( &", x, "->left," , a, ",GMP_RNDD)");
+     Ccode( void, "mpfr_set( &", x, "->right," , b, ",GMP_RNDU)");
+     moveToRRiandclear(x));
+
+export interval(a:RR, b:RR):RRi := interval(a,b,defaultPrecision);
+
 export infinityRR(prec:ulong,sign:int):RR := (
      x := newRRmutable(prec);
      Ccode(void, "mpfr_set_inf(",x,",",sign,")");
@@ -1163,16 +1211,36 @@ export (x:RR) + (y:int) : RR := (
      z := newRRmutable(precision0(x));
      Ccode( void, "mpfr_add_si(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
      moveToRRandclear(z));
+
+export (x:RRi) + (y:int) : RRi := (
+     z := newRRimutable(precision0(x));
+     Ccode( void, "mpfi_add_si(", z, ",",  x, ",",  y, ")" );
+     moveToRRiandclear(z));
      
 export (x:RR) + (y:ZZ) : RR := (
      z := newRRmutable(precision0(x));
      Ccode( void, "mpfr_add_z(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
      moveToRRandclear(z));
+
+export (x:RRi) + (y:ZZ) : RRi := (
+     z := newRRimutable(precision0(x));
+     Ccode( void, "mpfi_add_z(", z, ",",  x, ",",  y, ")" );
+     moveToRRiandclear(z));
      
 export (x:RR) + (y:QQ) : RR := (
      z := newRRmutable(precision0(x));
      Ccode( void, "mpfr_add_q(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
      moveToRRandclear(z));
+
+export (x:RRi) + (y:QQ) : RRi := (
+     z := newRRimutable(precision0(x));
+     Ccode( void, "mpfi_add_q(", z, ",",  x, ",",  y, ")" );
+     moveToRRiandclear(z));
+
+export (x:RRi) + (y:RR) : RRi := (
+     z := newRRimutable(precision0(x));
+     Ccode( void, "mpfi_add_fr(", z, ",",  x, ",",  y, ")" );
+     moveToRRiandclear(z));
 
 export - (y:RR) : RR := (
      z := newRRmutable(precision0(y));

--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -71,7 +71,7 @@ new ComplexField of Nothing' from ZZ := memoize(
 	       symbol precision => prec,
 	       symbol Engine => true,
 	       symbol isBasic => true,
-	       symbol baseRings => {ZZ,QQ,RR,RRi},
+	       symbol baseRings => {ZZ,QQ,RR},
 	       symbol RawRing => rawCC prec
 	       }))
 precision InexactField := R -> R.precision

--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -31,7 +31,7 @@ InexactField.synonym = "inexact field"
 raw InexactField := R -> R.RawRing
 
 RR.InexactField = RealField    = new Type of InexactField   ; RealField.synonym = "real field"
-RRi.InexactField = RealField    = new Type of InexactField   ; RealField.synonym = "real interval field"
+RRi.InexactField = RealIntervalField    = new Type of InexactField   ; RealField.synonym = "real interval field"
 CC.InexactField = ComplexField = new Type of InexactField; ComplexField.synonym = "complex field"
 
 Nothing' = Nothing					    -- maybe we'll want to rename it later...
@@ -157,7 +157,7 @@ promote(RR,QQ) := (z,QQ) -> if z === 0. then 0/1 else if isFinite z then (
      ) else error "promote(RR,QQ): non-finite number encountered"
 
 ring RR := x -> new RealField of RR' from precision x
-ring RRi := x -> new RealField of RRi' from precision x
+ring RRi := x -> new RealIntervalField of RRi' from precision x
 ring CC := x -> new ComplexField of CC' from precision x
 
 new RR from RawRingElement := (RRR,x) -> ( assert( RRR === RR ); rawToRR x)


### PR DESCRIPTION
Implementing functions for mpfi - in progress.

Implemented:
      toRRi of [ZZ, QQ, RR, and RRi]
      toRRi of (prec,[ZZ, QQ, RR, and RRi])
      interval of [ZZ,QQ,RR, and RRi]
      interval of (ZZ, [ZZ, QQ, RR, and RRi])
      interval of (prec, ZZ, [ZZ, QQ, RR, and RRi])
      Addition of intervals.

To do list:
     Other interval constructors
     Other operations between intervals
     Operations between intervals and numbers
     Functions on intervals (width, midpoint)
     Special functions on intervals
     Meaningful error messages
     Make -mpfi automatic in the configure.
     
Questions:
     Should interval reverse the order of an input if lhs>rhs?