### PR TITLE
Refactored regenerative cascade working on simple examples

### DIFF
--- a/M2/Macaulay2/packages/NumericalDecomposition/u-generation.m2
+++ b/M2/Macaulay2/packages/NumericalDecomposition/u-generation.m2
@@ -114,7 +114,9 @@ uGeneration {sph*(x-1)*(y-x^2), sph*(y-2)*(z-x^3)}
 end--
 restart
 needsPackage "NumericalDecomposition"
-n = 3
+n = 6
 R = CC[x_1..x_n,y_1..y_n]
 M = genericMatrix(R,n,2)
 F = for i from 1 to n-1 list det M^{i-1,i}
+V = uGeneration F
+decompose \ components V


### PR DESCRIPTION
@antonleykin @JoseMath

We checked that the new code works on "nice" examples, ie. complete intersections. The very next steps will be 

  1. To refactor code so that it doesn't depend on ``` hypersurfaceSection``` from ```NumericalAlgebraicGeometry```
  2. Rework the implementation ("u" vs "re" generation.)

In the above we'll need to decide how to deal with singular witness points. The simplest strategy for now: report with warning, then discard them. 

A long-term goal (very long-term?) would be to re-incorporate deflation sequences, which in turn motivates looking at multiprojective witness sets.