### PR TITLE
Suggested Msolve changes

### DIFF
--- a/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
@@ -71,10 +71,13 @@ TEST(MatrixIO, readPolynomialErrors)
 TEST(MatrixIO, readMsolve)
 {
   std::string filename { EXAMPLE_DIR"eg2-gb.ms" };
-  std::string contents = R"(#Reduced Groebner basis for input in characteristic 1235952427
-#for variable order x, y, z
-#w.r.t. grevlex monomial ordering
-#consisting of 4 elements:
+  std::string contents = R"(#Reduced Groebner basis data
+#---
+#field characteristic: 1235952427
+#variable order:       x, y, z
+#monomial order:       graded reverse lexicographical
+#length of basis:      4 elements sorted by increasing leading monomials
+#---
 [1*x^1+2*y^1+2*z^1+1235952426,
 1*y^1*z^1+494380972*z^2+370785728*y^1+247190485*z^1,
 1*y^2+988761941*z^2+741571456*y^1+494380971*z^1,

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -412,6 +412,7 @@ export {
 	"Test",
 	"TestInput",
 	"Thing",
+	"Threads",
 	"Time",
 	"Tor",
 	"Toric",

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -614,6 +614,7 @@ monoidSymbol  = (M, x) -> ( b := try baseName x;
     error("expected an index, symbol, or name of variable of the ring or monoid: ", toString x))
 
 -- also used in Elimination
+-- TODO: fails for tower rings!
 monoidIndices = (M, v) -> apply(v, monoidIndex_M)
 monoidIndex   = (M, x) -> ( b := try baseName x;
     if instance(x, ZZ)    then x else

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -613,13 +613,13 @@ monoidSymbol  = (M, x) -> ( b := try baseName x;
     and M.indexStrings#?x then M.indexSymbols#x     else
     error("expected an index, symbol, or name of variable of the ring or monoid: ", toString x))
 
--- also used in Elimination
--- TODO: fails for tower rings!
+-- also used in Elimination and Msolve
 monoidIndices = (M, v) -> apply(v, monoidIndex_M)
 monoidIndex   = (M, x) -> ( b := try baseName x;
     if instance(x, ZZ)    then x else
     if instance(x, List)  then monoidIndices(M, x) else
     if M.index#?b         then M.index#b else
+    try index x else -- last ditch attempt for ring elements
     error("expected an integer or variable of the ring or monoid: ", toString x))
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/shared.m2
+++ b/M2/Macaulay2/m2/shared.m2
@@ -31,3 +31,5 @@ protect Base
 protect Jacobian
 
 protect Iterate
+
+protect Threads

--- a/M2/Macaulay2/packages/FastMinors.m2
+++ b/M2/Macaulay2/packages/FastMinors.m2
@@ -64,7 +64,6 @@ export{
   "Rank", --a value for Strategy in isRankAtLeast
  -- "MutableSmallest",
  -- "MutableLargest",
-  "Threads",
   "MinorsCache",
   "Modulus",
 --  "MaxMinorsFunction", 
@@ -1698,7 +1697,6 @@ doc ///
         isRankAtLeast
         (isRankAtLeast, ZZ, Matrix)
         [isRankAtLeast, Verbose]
-        [isRankAtLeast, Threads]
     Headline
         determines if the matrix has rank at least a number
     Usage
@@ -1734,7 +1732,6 @@ doc ///
         getSubmatrixOfRank
         (getSubmatrixOfRank, ZZ, Matrix)
         [getSubmatrixOfRank, Verbose]
-        [getSubmatrixOfRank, Threads]
     Headline
         tries to find a submatrix of the given rank
     Usage
@@ -1998,7 +1995,6 @@ doc ///
         recursiveMinors
         (recursiveMinors, ZZ, Matrix)
         [recursiveMinors, MinorsCache]
-        [recursiveMinors, Threads]
         [recursiveMinors,Verbose]
         MinorsCache
     Headline
@@ -2106,12 +2102,14 @@ doc ///
 
 doc ///
     Key
-        Threads
+        [isRankAtLeast, Threads]
+	[getSubmatrixOfRank, Threads]
+	[recursiveMinors, Threads]
     Headline
         an option for various functions
     Description
         Text
-            Increasing this function may tell various functions to multithread their operations.  You may also want to increase {\tt allowableThreads}.
+            Increasing this option may tell various functions to multithread their operations.  You may also want to increase {\tt allowableThreads}.
     SeeAlso
         isRankAtLeast
         getSubmatrixOfRank

--- a/M2/Macaulay2/packages/Macaulay2Doc/options.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/options.m2
@@ -14,6 +14,7 @@ opts  = unique opts;
 
 optionalNames := select(unique \\ flatten \\ keys \ opts, s -> instance(s, Symbol) and isGlobalSymbol toString s and
     not isUndocumented(d := makeDocumentTag s) and (isMissingDoc d or headline d === "an optional argument"))
+optionalNames = unique join({ Threads }, optionalNames)
 
 optionalValues := unique(flatten \\ values \ opts
     | { Prune, Binomial, Test, Center, Right, Left, Flexible, Postfix } -- for manually added Symbols

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -173,6 +173,9 @@ msolveSaturate(Ideal,RingElement):=opt->(I,f)->(
     msolGB:=readMsolveOutputFile(R, mOut);
     return gens forceGB msolGB;
     );
+addHook((saturate, Ideal, RingElement), Strategy => Msolve,
+    -- msolveSaturate doesn't use any options of saturate, like DegreeLimit, etc.
+    (opts, I, f) -> try ideal msolveSaturate(I, f))
 
 msolveRealSolutions = method(TypicalValue => List,
     Options => msolveDefaultOptions ++ { "output type" => "rationalInterval" })

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -245,6 +245,8 @@ msolveRUR(Ideal):=opt->(I)->(
     return new HashTable from RUR;
     );
 
+load "./Msolve/tests.m2"
+
 beginDocumentation()
 
 doc ///

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -75,7 +75,7 @@ inputOkay Ideal := I -> (
 	if debugLevel > 0 then printerr "msolve input must be in a polynomial ring";
 	return false);
     if not isField K or instance(K, GaloisField) or precision K < infinity or char K > 2^31 then (
-	if debugLevel > 0 then printerr "msolve input must be over QQ or ZZ/p with chacteristic less than 2^32";
+	if debugLevel > 0 then printerr "msolve input must be over QQ or ZZ/p with chacteristic less than 2^31";
 	return false);
     true)
 
@@ -258,13 +258,13 @@ Node
 	      The package has functions to compute Groebner basis, in
 	      @TO GRevLex@ order only, for ideals with rational or finite
 	      field coefficients. Finite field characteristics must be
-	      less than $2^{32}$. There are also functions to
+	      less than $2^{31}$. There are also functions to
 	      compute elimination ideals, for ideals with rational or
 	      finite field coefficients.
 	      
 	      The @TO2 {"Saturation::saturate", "saturation"}@ of an ideal by a single polynomial may be
 	      computed for ideals with finite field coefficients, again
-	      with characteristic less than $2^{32}$.
+	      with characteristic less than $2^{31}$.
 	      
 	      For zero dimensional polynomial ideals, with integer or
 	      rational coefficients, there are functions to compute all
@@ -304,7 +304,7 @@ Node
     	msolveGB(I)
     Inputs
     	I:Ideal
-	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@, @TO QQ@, or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{32}$.
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@, @TO QQ@, or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$.
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
@@ -344,7 +344,7 @@ Node
     	msolveLeadMonomials(I)
     Inputs
     	I:Ideal
-	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@, @TO QQ@, or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{32}$.
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@, @TO QQ@, or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$.
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
@@ -488,7 +488,7 @@ Node
     	msolveSaturate(I)
     Inputs
     	I:Ideal
-	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{32}$.
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$.
 	f:RingElement
 	    a polynomial in the same ring as I.    
 	Threads => ZZ -- number of processor threads to use
@@ -521,7 +521,7 @@ Node
     	msolveEliminate(I,elimVars)
     Inputs
     	I:Ideal
-	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@ or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{32}$.
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@ or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$.
 	elimVars:List
 	    of variables in the same ring as @TT "I"@, these variables will be eliminated.
 	Threads => ZZ -- number of processor threads to use

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -277,7 +277,7 @@ Node
      Key
      	  Msolve
      Headline
-     	  Macaulay2 interface for msolve; computes real solutions and Groebner basis, etc. 
+	  Macaulay2 interface for msolve; computes real solutions and Groebner basis, etc.
      Description
      	  Text
               This package provides a Macaulay2 interface for the
@@ -329,20 +329,27 @@ Node
        [msolveGB, Threads]
        [msolveGB, Verbosity]
     Headline
-    	Computes generators of a Groebner basis in GrevLex order.
+	compute generators of a Groebner basis in GRevLex order
     Usage
     	msolveGB(I)
     Inputs
     	I:Ideal
-	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@, @TO QQ@, or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$.
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO QQ@ or
+	    @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         GB:Matrix
-	    a matrix whose columns form a Groebner basis for the input ideal I, in the GrevLex order.    
+	    whose columns form a Groebner basis for the input ideal I, in the GRevLex order
     Description 
         Text
-    	    This functions uses the F4 implementation in the msolve package to compute a Groebner basis, in GrevLex order, of a polynomial ideal with either rational coefficients or finite field coefficients with characteristic less than 2^32. If the input ideal is a polynomial ring with monomial order other than GrevLex a GrevLex basis is returned (and no warning is given). The input ideal may also be given in a ring with integer coefficients, in this case a Groebner basis for the given ideal over the rationals  will be computed, denominators will be cleared, and the output will be a Groebner basis over the rationals in GrevLex order with integer coefficients.
+	    This functions uses the F4 implementation in the msolve package to compute a Groebner basis,
+	    in GRevLex order, of a polynomial ideal with either rational coefficients or finite field
+	    coefficients with characteristic less than $2^{31}$. If the input ideal is a polynomial ring
+	    with monomial order other than GRevLex a GRevLex basis is returned (and no warning is given).
+	    The input ideal may also be given in a ring with integer coefficients, in this case a Groebner
+	    basis for the given ideal over the rationals  will be computed, denominators will be cleared,
+	    and the output will be a Groebner basis over the rationals in GRevLex order with integer coefficients.
     	Text
 	    First an example over a finite field
 	Example
@@ -369,20 +376,28 @@ Node
        [msolveLeadMonomials, Threads]
        [msolveLeadMonomials, Verbosity]
     Headline
-    	Computes the leading monomials of a Groebner basis in GrevLex order.
+	compute the leading monomials of a Groebner basis in GRevLex order
     Usage
     	msolveLeadMonomials(I)
     Inputs
     	I:Ideal
-	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@, @TO QQ@, or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$.
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO QQ@ or
+	    @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         GB:Matrix
-	    a matrix whose columns are the leading monomials (of a Groebner basis for) the input ideal I, in the GrevLex order.    
+	    whose columns are the leading monomials (of a Groebner basis for) the input ideal I, in the GRevLex order
     Description 
         Text
-    	    This functions uses the F4 implementation in the msolve package to compute leading monomials via a Groebner basis, in GrevLex order, of a polynomial ideal with either rational coefficients or finite field coefficients with characteristic less than 2^32. If the input ideal is a polynomial ring with monomial order other than GrevLex a GrevLex basis is returned (and no warning is given). The input ideal may also be given in a ring with integer coefficients, in this case a Groebner basis for the given ideal over the rationals  will be computed, denominators will be cleared, and the output will be a Groebner basis over the rationals in GrevLex order with integer coefficients.
+	    This functions uses the F4 implementation in the msolve package to compute leading
+	    monomials via a Groebner basis, in GRevLex order, of a polynomial ideal with either
+	    rational coefficients or finite field coefficients with characteristic less than $2^{31}$.
+	    If the input ideal is a polynomial ring with monomial order other than GRevLex a GRevLex
+	    basis is returned (and no warning is given). The input ideal may also be given in a ring
+	    with integer coefficients, in this case a Groebner basis for the given ideal over the
+	    rationals  will be computed, denominators will be cleared, and the output will be a
+	    Groebner basis over the rationals in GRevLex order with integer coefficients.
     	Text
 	    First an example over a finite field
 	Example
@@ -392,7 +407,11 @@ Node
 	    degree lm
 	    dim lm	    
 	Text
-	    Now the same example over the rationals; note over the rationals msolve first computes over a finite field and when only the leading monomials are asked for the correct leading monomials will be returned but the full Groebner basis over Q will not be computed. Hence if only degree and dimension are desired this command will often be faster that the Groeber basis command.  
+	    Now the same example over the rationals; note over the rationals msolve first
+	    computes over a finite field and when only the leading monomials are asked for
+	    the correct leading monomials will be returned but the full Groebner basis over
+	    @TO QQ@ will not be computed. Hence if only degree and dimension are desired
+	    this command will often be faster that the Groebner basis command.
 	Example 
 	    R=QQ[z_1..z_3]
 	    I=ideal(7*z_1*z_2+5*z_2*z_3+z_3^2+z_1+5*z_3+10,8*z_1^2+13*z_1*z_3+10*z_3^2+z_2+z_1)
@@ -409,20 +428,34 @@ Node
        [msolveRealSolutions, Threads]
        [msolveRealSolutions, Verbosity]
     Headline
-    	Uses symbolic methods to compute all real solutions to a zero dim systems.
+	compute all real solutions to a zero dimensional system using symbolic methods
     Usage
     	msolveRealSolutions(I)
     Inputs
     	I:Ideal
-	    which is zero dimensional, in a polynomial ring with coefficients over @TO ZZ@ or @TO QQ@.
+	    which is zero dimensional, in a polynomial ring with coefficients over @TO QQ@
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         Sols:List
-	    a list of lists, each entry in the list Sol consists of a list representing the coordinates of a solution. By default each solution coordinate value is also represented by a two element list of rational numbers, {a, b}, this means that that coordinate of the solution has a value greater than or equal to a and less than or equal to b. This interval is computed symbolically and its correctness is guaranteed by exact methods.      
+	    of lists; each entry in the list @TT "Sols"@ consists of a list representing
+	    the coordinates of a solution. By default each solution coordinate value is
+	    also represented by a two element list of rational numbers, {a, b}, this means
+	    that that coordinate of the solution has a value greater than or equal to a and
+	    less than or equal to b. This interval is computed symbolically and its correctness
+	    is guaranteed by exact methods.
     Description 
         Text
-    	    This functions uses the msolve package to compute the real solutions to a zero dimensional polynomial ideal with either integer or rational coefficients. The output is a list of lists, each entry in the list Sol consists of a list representing the coordinates of a solution. By default each solution coordinate value is also represented by a two element list of rational numbers, {a, b}, this means that that coordinate of the solution has a value greater than or equal to a and less than or equal to b. This interval is computed symbolically and its correctness is guaranteed by exact methods. Note that using the option Output one may specify the output in terms of either a float interval with "floatInterval" or an average of the interval endpoints as a single float with "float".      
+	    This functions uses the msolve package to compute the real solutions to a zero
+	    dimensional polynomial ideal with either integer or rational coefficients.
+	    The output is a list of lists, each entry in the list Sol consists of a list
+	    representing the coordinates of a solution. By default each solution coordinate
+	    value is also represented by a two element list of rational numbers, {a, b},
+	    this means that that coordinate of the solution has a value greater than or
+	    equal to a and less than or equal to b. This interval is computed symbolically
+	    and its correctness is guaranteed by exact methods. Note that using the option
+	    Output one may specify the output in terms of either a float interval with
+	    "floatInterval" or an average of the interval endpoints as a single float with "float".
 
     	Text
 	    First an example over a finite field
@@ -437,7 +470,8 @@ Node
 	    floatAproxSols=msolveRealSolutions(I,"output type"=>"float")
 	    	    
 	Text
-	    Note in cases where solutions have multiplicity this is not returned, but the presence of multiplicity also does not reduce accuracy or reliability in any way.   
+	    Note in cases where solutions have multiplicity this is not returned, but the presence
+	    of multiplicity also does not reduce accuracy or reliability in any way.
 	Example 
 	    f = (x_1-1)*x_1^3
 	    g = (x_2-5/2)*(x_2-1/2)
@@ -453,22 +487,26 @@ Node
        [msolveRUR, Threads]
        [msolveRUR, Verbosity]
     Headline
-    	Uses symbolic methods to compute the rational univariate representation.
+	compute the rational univariate representation using symbolic methods
     Usage
     	msolveRUR(I)
     Inputs
     	I:Ideal
-	    which is zero dimensional, in a polynomial ring with coefficients over @TO ZZ@ or @TO QQ@.
+	    which is zero dimensional, in a polynomial ring with coefficients over @TO QQ@
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         RUR:HashTable
-	    a HashTable with 6 keys giving the rational univariate representation of I.     
+	    with 6 keys giving the rational univariate representation of I
     Description 
         Text
-    	    This functions uses the msolve package to compute the rational univariate representation (RUR) of a zero dimensional polynomial ideal with either integer or rational coefficients.
+	    This functions uses the msolve package to compute the rational univariate representation
+	    (RUR) of a zero dimensional polynomial ideal with either integer or rational coefficients.
 	    
-	    The RUR gives a parametrization for all complex solutions to the input system. For a complete definition of the RUR see the paper: Rouillier, Fabrice (1999). "Solving Zero-Dimensional Systems Through the Rational Univariate Representation". Appl. Algebra Eng. Commun. Comput. 9 (9): 433–461.
+	    The RUR gives a parametrization for all complex solutions to the input system.
+	    For a complete definition of the RUR see the paper: Rouillier, Fabrice (1999).
+	    "Solving Zero-Dimensional Systems Through the Rational Univariate Representation".
+	    Appl. Algebra Eng. Commun. Comput. 9 (9): 433–461.
 	    
 	    If I is a zero dimensional ideal in QQ[x_1..x_n] then the RUR is given by:
 	    
@@ -480,13 +518,16 @@ Node
 	    
 	    The key "findRootsUniPoly" gives the polynomial w(T) above.
 	    
-	    The key "denominator"  gives the polynomial w'(T), which is the derivative of w(T) and is the denominator of each coordinate above.
+	    The key "denominator"  gives the polynomial w'(T), which is the derivative of w(T) and
+	    is the denominator of each coordinate above.
 	    
-	    The key "numerator" gives a list {v_1(T), .. , v_n(T)} of length n above, with n the number of variables, where the polynomial v_i(T) gives the numerator of the ith coordinate.
+	    The key "numerator" gives a list {v_1(T), .. , v_n(T)} of length n above, with n the
+	    number of variables, where the polynomial v_i(T) gives the numerator of the ith coordinate.
 	    
-	    The key "var" gives the variable name in the univariate polynomial ring; by default this is: T.
+	    The key "var" gives the variable name in the univariate polynomial ring; by default this is: "T".
 	    
-	    The key "T" gives the linear relation between the variables of the ring of I and the single variable, which is denoted T above.
+	    The key "T" gives the linear relation between the variables of the ring of I and
+	    the single variable, which is denoted T above.
 	    
     	Text
 	    A simple example, where the input ideal is zero dimensional and radical.
@@ -513,29 +554,35 @@ Node
        [msolveSaturate, Threads]
        [msolveSaturate, Verbosity]
     Headline
-    	Computes a Groebner basis for the saturation of an ideal by a single polynomial in GrevLex order; only works over a finite field.
+	compute a Groebner basis for the saturation of an ideal by a single polynomial in GRevLex order
     Usage
     	msolveSaturate(I)
     Inputs
     	I:Ideal
-	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$.
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over
+	    @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic more than $2^16$ and less than $2^{31}$
 	f:RingElement
 	    a polynomial in the same ring as I.    
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         GB:Matrix
-	    a matrix whose columns form a Groebner basis for the ideal I:f^\infty, in the GrevLex order.    
+	    whose columns form a Groebner basis for the ideal $I:f^\infty$, in the GRevLex order
     Description 
         Text
-    	    This functions uses the saturation implementation in the msolve package to compute a Groebner basis, in GrevLex order, of I:f^\infty, that is of the saturation of the ideal I by the principal ideal generated by the polynomial f.
+	    This functions uses the F4SAT algorithm implementated in the msolve library to compute a
+	    Groebner basis, in GRevLex order, of $I:f^\infty$, that is of the saturation of the
+	    ideal $I$ by the principal ideal generated by the polynomial $f$.
     	Text
 	    First an example; note the ring must be a polynomial ring over a finite field
 	Example
 	    R=ZZ/1073741827[z_1..z_3]
 	    I=ideal(z_1*(z_2^2-17*z_1-z_3^3),z_1*z_2)
 	    satMsolve=ideal msolveSaturate(I,z_1)
-	    satM2=saturate(I,z_1)	    	    
+	    satM2=saturate(I,z_1)
+    Caveat
+	Currently this algorithm only works over prime fields in characteristic between $2^{16}$ and $2^{31}$.
+
 Node 
     Key
     	msolveEliminate
@@ -546,19 +593,20 @@ Node
        [msolveEliminate, Threads]
        [msolveEliminate, Verbosity]
     Headline
-    	Computes the elimination ideal of a given ideal.
+	compute the elimination ideal of a given ideal
     Usage
     	msolveEliminate(I,elimVars)
     Inputs
     	I:Ideal
-	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@ or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$.
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over
+	    @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{31}$
 	elimVars:List
-	    of variables in the same ring as @TT "I"@, these variables will be eliminated.
+	    of variables in the same ring as @TT "I"@, these variables will be eliminated
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         GB:Matrix
-	    a matrix whose columns are generators for the elimination ideal.    
+	    whose columns are generators for the elimination ideal
     Description 
         Text
             This function takes as input a polynomial ideal and
@@ -566,9 +614,9 @@ Node
             variables specified in the inputted list.
 
             The behavior is very different over finite (prime) fields, and the rationals.
-            Over QQ, the subideal over a smaller set of variables eliminating the given ones is returned.
+	    Over @TO QQ@, the subideal over a smaller set of variables eliminating the given ones is returned.
             Over a finite field, the Groebner basis in the product order eliminating the given block of variables
-            is returned (warning: this is a copy of the ring with (potentially) permuted variables.
+	    is returned (warning: this is a copy of the ring with potentially permuted variables).
         Text
 	    First an example over the rationals. 
 	Example
@@ -580,8 +628,7 @@ Node
 	    sub(M2elim,ring Msolveelim)==Msolveelim    
 	Text
             We can also work over a finite field. Here we get the full
-            Groebner basis in the permuted variables with a block
-            order.
+            Groebner basis in the permuted variables with a block order.
         Example 
 	    R = ZZ/1073741827[x,y,a,b,c,d]
 	    f = c*x^2+a*x+b*y^2+d*x*y+y

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -43,13 +43,13 @@ if msolveProgram === null then (
 	msolveProgram = findProgram("msolve", "msolve --help", Verbose => debugLevel > 0)))
 
 msolveDefaultOptions = new OptionTable from {
-    "number of threads" => allowableThreads,
+    Threads => allowableThreads,
     Verbosity => 0,
     }
 
 msolve = (mIn, mOut, args, opts) -> runProgram(msolveProgram,
     demark_" " { args,
-	"-t", toString opts#"number of threads",
+	"-t", toString opts.Threads,
 	"-v", toString opts.Verbosity,
 	"-f", mIn, "-o", mOut },
     KeepFiles => true,
@@ -289,10 +289,10 @@ Node
 
 	      For all functions the option Verbosity can be used. It has levels 0, 1, 2. The default is 0. 
 
-	      Msolve supports parallel computations. The option "number of threads" is used to set this. 
+	      Msolve supports parallel computations. The option @TT "Threads"@ is used to set this.
 	      The default value is allowableThreads, but this can be set manually by the user when 
 	      calling a function. E.g. for an ideal I:
-	      msolveGB(I, Verbosity=>2, "number of threads"=>6)
+	      msolveGB(I, Verbosity => 2, Threads => 6)
 	      
 	      
 	      References:
@@ -301,7 +301,9 @@ Node
 Node 
     Key
     	msolveGB
-	(msolveGB, Ideal)
+       (msolveGB, Ideal)
+       [msolveGB, Threads]
+       [msolveGB, Verbosity]
     Headline
     	Computes generators of a Groebner basis in GrevLex order.
     Usage
@@ -309,6 +311,8 @@ Node
     Inputs
     	I:Ideal
 	    an ideal in a polynomial ring with GrevLex order and either rational coefficients, integer coefficients, or finite field coefficients. For a finite field the characteristic must be less than 2^32. 
+	Threads => ZZ -- number of processor threads to use
+	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         GB:Matrix
 	    a matrix whose columns form a Groebner basis for the input ideal I, in the GrevLex order.    
@@ -337,7 +341,9 @@ Node
 Node 
     Key
     	msolveLeadMonomials
-	(msolveLeadMonomials, Ideal)
+       (msolveLeadMonomials, Ideal)
+       [msolveLeadMonomials, Threads]
+       [msolveLeadMonomials, Verbosity]
     Headline
     	Computes the leading monomials of a Groebner basis in GrevLex order.
     Usage
@@ -345,6 +351,8 @@ Node
     Inputs
     	I:Ideal
 	    an ideal in a polynomial ring with GrevLex order and either rational coefficients, integer coefficients, or finite field coefficients. For a finite field the characteristic must be less than 2^32. 
+	Threads => ZZ -- number of processor threads to use
+	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         GB:Matrix
 	    a matrix whose columns are the leading monomials (of a Groebner basis for) the input ideal I, in the GrevLex order.    
@@ -373,7 +381,9 @@ Node
 Node 
     Key
     	msolveRealSolutions
-	(msolveRealSolutions, Ideal)
+       (msolveRealSolutions, Ideal)
+       [msolveRealSolutions, Threads]
+       [msolveRealSolutions, Verbosity]
     Headline
     	Uses symbolic methods to compute all real solutions to a zero dim systems.
     Usage
@@ -381,6 +391,8 @@ Node
     Inputs
     	I:Ideal
 	    a zero dimensional ideal in a polynomial ring with either rational or integer coefficients. 
+	Threads => ZZ -- number of processor threads to use
+	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         Sols:List
 	    a list of lists, each entry in the list Sol consists of a list representing the coordinates of a solution. By default each solution coordinate value is also represented by a two element list of rational numbers, {a, b}, this means that that coordinate of the solution has a value greater than or equal to a and less than or equal to b. This interval is computed symbolically and its correctness is guaranteed by exact methods.      
@@ -416,7 +428,9 @@ Node
 Node 
     Key
     	msolveRUR
-	(msolveRUR, Ideal)
+       (msolveRUR, Ideal)
+       [msolveRUR, Threads]
+       [msolveRUR, Verbosity]
     Headline
     	Uses symbolic methods to compute the rational univariate representation.
     Usage
@@ -424,6 +438,8 @@ Node
     Inputs
     	I:Ideal
 	    a zero dimensional ideal in a polynomial ring with either rational or integer coefficients. 
+	Threads => ZZ -- number of processor threads to use
+	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         RUR:HashTable
 	    a HashTable with 6 keys giving the rational univariate representation of I.     
@@ -473,7 +489,9 @@ Node
 Node 
     Key
     	msolveSaturate
-	(msolveSaturate, Ideal,RingElement)
+       (msolveSaturate, Ideal,RingElement)
+       [msolveSaturate, Threads]
+       [msolveSaturate, Verbosity]
     Headline
     	Computes a Groebner basis for the saturation of an ideal by a single polynomial in GrevLex order; only works over a finite field.
     Usage
@@ -483,6 +501,8 @@ Node
 	    an ideal in a polynomial ring with GrevLex order and finite field coefficients. The finite field must have characteristic less than 2^32. 
 	f:RingElement
 	    a polynomial in the same ring as I.    
+	Threads => ZZ -- number of processor threads to use
+	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         GB:Matrix
 	    a matrix whose columns form a Groebner basis for the ideal I:f^\infty, in the GrevLex order.    
@@ -503,6 +523,8 @@ Node
 	(msolveEliminate, List,Ideal)
 	(msolveEliminate, Ideal,RingElement)
 	(msolveEliminate, RingElement,Ideal)
+       [msolveEliminate, Threads]
+       [msolveEliminate, Verbosity]
     Headline
     	Computes the elimination ideal of a given ideal.
     Usage
@@ -512,6 +534,8 @@ Node
 	    an ideal in a polynomial ring with rational or finite field coefficients. If working over a finite field, it must have characteristic less than 2^32. 
 	elimVars:List
 	    a list of variables in the same ring as I, these variables will be eliminated.    
+	Threads => ZZ -- number of processor threads to use
+	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
         GB:Matrix
 	    a matrix whose columns are generators for the elimination ideal.    

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -163,6 +163,8 @@ msolveSaturate(Ideal,RingElement):=opt->(I,f)->(
     gR:=toString(gens R);
     l1:=substring(1,#gR-2,gR);
     l2:=char R;
+    -- see https://github.com/algebraic-solving/msolve/issues/165
+    if l2 < 2^16 or l2 =!= 1073741827 then error "msolve: unsupported prime for saturation";
     gI:=toString flatten entries gens I;
     if (isField(kk) and (char(kk)==0)) then gI=replace("[)(]","",gI);
     Igens:=replace(" ",""|newline,substring(1,#gI-2,gI));

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -67,23 +67,17 @@ readMsolveOutputFile(Ring,String) := Matrix => (R,mOut) -> if use'readMsolveOutp
     	matrix {M2Out};
     	)
 
-inputOkay=method(TypicalValue=>Boolean);
-inputOkay(Ideal):=I->(
-    R:=ring I;
-    if not instance(R,PolynomialRing) then (print "input must be in a polynomial ring over a field";return false;);
-    kk:=coefficientRing(R);
-    if (instance(kk,InexactFieldFamily) or instance(kk,InexactField)) then(
-        print "input must be over the rationals or a (prime) finite field of chacteristic less than 2^32";
-	return false;
-	);
-    if char(kk)>0 then (
-	if (char(kk)>2^32) then(
-	    print "input must be over the rationals or a (prime) finite field of chacteristic less than 2^32";
-	    return false;
-	    );
-	);
-    return true;
-    );
+inputOkay = method(TypicalValue => Boolean)
+inputOkay Ideal := I -> (
+    R := first flattenRing I;
+    K := ultimate(coefficientRing, R);
+    if not instance(R, PolynomialRing) then (
+	if debugLevel > 0 then printerr "msolve input must be in a polynomial ring";
+	return false);
+    if not isField K or instance(K, GaloisField) or precision K < infinity or char K > 2^31 then (
+	if debugLevel > 0 then printerr "msolve input must be over QQ or ZZ/p with chacteristic less than 2^32";
+	return false);
+    true)
 
 msolveGB = method(TypicalValue => Matrix, Options => msolveDefaultOptions)
 msolveGB(Ideal):=opt->I->(

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -42,6 +42,11 @@ if msolveProgram === null then (
     else ( printerr "warning: msolve found but its version is older than 0.6.7";
 	msolveProgram = findProgram("msolve", "msolve --help", Verbose => debugLevel > 0)))
 
+msolveDefaultOptions = new OptionTable from {
+    "number of threads" => allowableThreads,
+    Verbosity => 0,
+    }
+
 msolve = (mIn, mOut, args, opts) -> runProgram(msolveProgram,
     demark_" " { args,
 	"-t", toString opts#"number of threads",
@@ -79,7 +84,8 @@ inputOkay(Ideal):=I->(
 	);
     return true;
     );
-msolveGB=method(TypicalValue=>Matrix, Options=>{Verbosity=>0, "number of threads"=>allowableThreads});
+
+msolveGB = method(TypicalValue => Matrix, Options => msolveDefaultOptions)
 msolveGB(Ideal):=opt->I->(
     if not inputOkay(I) then error "Problem with input, please refer to documentation.";
     mIn:=temporaryFileName()|".ms";
@@ -98,7 +104,8 @@ msolveGB(Ideal):=opt->I->(
     msolGB:=readMsolveOutputFile(R, mOut);
     return gens forceGB msolGB;
     );
-msolveLeadMonomials=method(TypicalValue=>Matrix, Options=>{Verbosity=>0, "number of threads"=>allowableThreads});
+
+msolveLeadMonomials = method(TypicalValue => Matrix, Options => msolveDefaultOptions)
 msolveLeadMonomials(Ideal):=opt->(I)->(
     if not inputOkay(I) then error "Problem with input, please refer to documentation.";
     mIn:=temporaryFileName()|".ms";
@@ -117,7 +124,8 @@ msolveLeadMonomials(Ideal):=opt->(I)->(
     msolGB:=readMsolveOutputFile(R, mOut);
     return gens forceGB msolGB;
     );
-msolveEliminate=method(Options=>{Verbosity=>0, "number of threads"=>allowableThreads});
+
+msolveEliminate = method(Options => msolveDefaultOptions)
 msolveEliminate(Ideal,RingElement):=Ideal =>opt-> (I,elimvar)->(
     return msolveEliminate(I,{elimvar});
     );
@@ -152,7 +160,7 @@ msolveEliminate(Ideal,List):=Ideal => opt->(J,elimvars)->(
       ideal readMsolveOutputFile(R, mOut)
     )
 
-msolveSaturate=method(TypicalValue=>Matrix, Options=>{Verbosity=>0, "number of threads"=>allowableThreads});
+msolveSaturate = method(TypicalValue => Matrix, Options => msolveDefaultOptions)
 msolveSaturate(Ideal,RingElement):=opt->(I,f)->(
     if not inputOkay(I) then error "Problem with input, please refer to documentation.";
     mIn:=temporaryFileName()|".ms";
@@ -172,7 +180,8 @@ msolveSaturate(Ideal,RingElement):=opt->(I,f)->(
     return gens forceGB msolGB;
     );
 
-msolveRealSolutions=method(TypicalValue=>List,Options => {"output type"=>"rationalInterval",Verbosity=>0, "number of threads"=>allowableThreads});
+msolveRealSolutions = method(TypicalValue => List,
+    Options => msolveDefaultOptions ++ { "output type" => "rationalInterval" })
 msolveRealSolutions(Ideal):=opt->(I)->(
     if not inputOkay(I) then error "Problem with input, please refer to documentation.";
     mIn:=temporaryFileName()|".ms";
@@ -198,7 +207,8 @@ msolveRealSolutions(Ideal):=opt->(I)->(
     if opt#"output type"=="floatInterval" then return (1.0*sols);
     if opt#"output type"=="float" then return (for s in sols list(for s1 in s list sum(s1)/2.0));
     );
-msolveRUR=method(TypicalValue=>List,Options=>{Verbosity=>0, "number of threads"=>allowableThreads});
+
+msolveRUR = method(TypicalValue => List, Options => msolveDefaultOptions)
 msolveRUR(Ideal):=opt->(I)->(
     if not inputOkay(I) then error "Problem with input, please refer to documentation.";
     mIn:=temporaryFileName()|".ms";

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -247,8 +247,8 @@ msolveRUR(Ideal):=opt->(I)->(
     );
 
 beginDocumentation()
-multidoc ///
 
+doc ///
 Node 
      Key
      	  Msolve
@@ -256,22 +256,21 @@ Node
      	  Macaulay2 interface for msolve; computes real solutions and Groebner basis, etc. 
      Description
      	  Text
-
               This package provides a Macaulay2 interface for the
-              msolve package (https://msolve.lip6.fr/) developed by
+	      msolve library [1] developed by
               Jérémy Berthomieu, Christian Eder, and Mohab Safey El
               Din.
 	      
 	      The package has functions to compute Groebner basis, in
-	      GRevLex order only, for ideals with rational or finite
+	      @TO GRevLex@ order only, for ideals with rational or finite
 	      field coefficients. Finite field characteristics must be
-	      less than 2^32. There are also functions to
+	      less than $2^{32}$. There are also functions to
 	      compute elimination ideals, for ideals with rational or
 	      finite field coefficients.
 	      
-	      The saturation of an ideal by a single polynomial may be
+	      The @TO2 {"Saturation::saturate", "saturation"}@ of an ideal by a single polynomial may be
 	      computed for ideals with finite field coefficients, again
-	      with characteristic less than 2^32.
+	      with characteristic less than $2^{32}$.
 	      
 	      For zero dimensional polynomial ideals, with integer or
 	      rational coefficients, there are functions to compute all
@@ -281,23 +280,24 @@ Node
 	      The M2 interface assumes that the binary executable is
 	      named "msolve" is on the executable path.
 
-	      
 	      Rings with double subscript variables are NOT supported,
 	      i.e. QQ[x_(1,1)..x_(1,3)] will NOT work. 
 	      You should use rings with single subscript, e.g., QQ[x_1..x_5],
 	      or rings with some characters as variables, e.g. QQ[a..d] or QQ[aa,bcd,x1] etc.
 
-	      For all functions the option Verbosity can be used. It has levels 0, 1, 2. The default is 0. 
+	      For all functions the option @TT "Verbosity"@ can be used.
+	      It has levels 0, 1, 2. The default is 0.
 
 	      Msolve supports parallel computations. The option @TT "Threads"@ is used to set this.
 	      The default value is allowableThreads, but this can be set manually by the user when 
 	      calling a function. E.g. for an ideal I:
+	  Example
+	      R = QQ[x,y,z]
+	      I = ideal(x, y, z)
 	      msolveGB(I, Verbosity => 2, Threads => 6)
-	      
-	      
-	      References:
-	      [1] msolve: https://msolve.lip6.fr/
-	      
+    References
+      [1] The msolve library: @HREF {"https://msolve.lip6.fr"}@;
+
 Node 
     Key
     	msolveGB
@@ -310,7 +310,7 @@ Node
     	msolveGB(I)
     Inputs
     	I:Ideal
-	    an ideal in a polynomial ring with GrevLex order and either rational coefficients, integer coefficients, or finite field coefficients. For a finite field the characteristic must be less than 2^32. 
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@, @TO QQ@, or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{32}$.
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
@@ -350,7 +350,7 @@ Node
     	msolveLeadMonomials(I)
     Inputs
     	I:Ideal
-	    an ideal in a polynomial ring with GrevLex order and either rational coefficients, integer coefficients, or finite field coefficients. For a finite field the characteristic must be less than 2^32. 
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@, @TO QQ@, or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{32}$.
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
@@ -390,7 +390,7 @@ Node
     	msolveRealSolutions(I)
     Inputs
     	I:Ideal
-	    a zero dimensional ideal in a polynomial ring with either rational or integer coefficients. 
+	    which is zero dimensional, in a polynomial ring with coefficients over @TO ZZ@ or @TO QQ@.
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
@@ -403,11 +403,10 @@ Node
     	Text
 	    First an example over a finite field
 	Example
-	    n=3
-	    R=QQ[x_1..x_n]
+	    R = QQ[x_1..x_3]
 	    f = (x_1-1)*x_1
 	    g = (x_2-5/2)*(x_2-1/2)
-	    h=(x_3-2)*(x_3-1)
+	    h = (x_3-2)*(x_3-1)
 	    I = ideal (f,g,h)
 	    sols=msolveRealSolutions(I)
 	    floatSolsInterval=msolveRealSolutions(I,"output type"=>"floatInterval")
@@ -416,11 +415,9 @@ Node
 	Text
 	    Note in cases where solutions have multiplicity this is not returned, but the presence of multiplicity also does not reduce accuracy or reliability in any way.   
 	Example 
-	    n=3
-	    R=QQ[x_1..x_n]
 	    f = (x_1-1)*x_1^3
 	    g = (x_2-5/2)*(x_2-1/2)
-	    h=(x_3-2)*(x_3-1)
+	    h = (x_3-2)*(x_3-1)
 	    I = ideal (f,g,h)
 	    sols=msolveRealSolutions(I)
 	    floatSolsInterval=msolveRealSolutions(I,"output type"=>"floatInterval")
@@ -437,7 +434,7 @@ Node
     	msolveRUR(I)
     Inputs
     	I:Ideal
-	    a zero dimensional ideal in a polynomial ring with either rational or integer coefficients. 
+	    which is zero dimensional, in a polynomial ring with coefficients over @TO ZZ@ or @TO QQ@.
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
@@ -470,11 +467,10 @@ Node
     	Text
 	    A simple example, where the input ideal is zero dimensional and radical.
 	Example
-	    n=3
-	    R=QQ[x_1..x_n]
+	    R = QQ[x_1..x_3]
 	    f = (x_1-1)
 	    g = (x_2-2)
-	    h=(x_3^2-9)
+	    h = (x_3^2-9)
 	    I = ideal (f,g,h)
 	    decompose I
 	    rur=msolveRUR(I)
@@ -498,7 +494,7 @@ Node
     	msolveSaturate(I)
     Inputs
     	I:Ideal
-	    an ideal in a polynomial ring with GrevLex order and finite field coefficients. The finite field must have characteristic less than 2^32. 
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{32}$.
 	f:RingElement
 	    a polynomial in the same ring as I.    
 	Threads => ZZ -- number of processor threads to use
@@ -531,9 +527,9 @@ Node
     	msolveEliminate(I,elimVars)
     Inputs
     	I:Ideal
-	    an ideal in a polynomial ring with rational or finite field coefficients. If working over a finite field, it must have characteristic less than 2^32. 
+	    in a polynomial ring with @TO GRevLex@ order and coefficients over @TO ZZ@ or @TO2 {"finite fields", TT "ZZ/p"}@ in characteristic less than $2^{32}$.
 	elimVars:List
-	    a list of variables in the same ring as I, these variables will be eliminated.    
+	    of variables in the same ring as @TT "I"@, these variables will be eliminated.
 	Threads => ZZ -- number of processor threads to use
 	Verbosity => ZZ -- level of verbosity between 0, 1, and 2
     Outputs
@@ -565,10 +561,10 @@ Node
         Example 
 	    R = ZZ/1073741827[x,y,a,b,c,d]
 	    f = c*x^2+a*x+b*y^2+d*x*y+y
-	    g =diff(x,f)
-	    h=diff(y,f)
-	    M2elim=eliminate({x,y},ideal(f,g,h))
-	    Msolveelim=msolveEliminate({x,y},ideal(f,g,h))
+	    g = diff(x,f)
+	    h = diff(y,f)
+	    M2elim = eliminate({x,y}, ideal(f,g,h))
+	    Msolveelim = msolveEliminate({x,y}, ideal(f,g,h))
 	    M2elim_0 == sub(Msolveelim_0, R)
 ///	      
 

--- a/M2/Macaulay2/packages/Msolve/tests.m2
+++ b/M2/Macaulay2/packages/Msolve/tests.m2
@@ -1,0 +1,15 @@
+TEST ///
+  K = ZZ/1073741827
+  R = K[x_(0,0), x_(0,1)]
+  I = ideal(2*x_(0,0)+3*x_(0,1))
+  assert(I == ideal msolveSaturate(I, x_(0,0)))
+  assert(I == saturate(I, x_(0,0), Strategy => Msolve))
+
+  -- c.f. https://github.com/algebraic-solving/msolve/issues/165
+  K = ZZ/11
+  R = K[x_(0,0), x_(0,1)]
+  I = ideal(2*x_(0,0)+3*x_(0,1))
+  assert(try (ideal msolveSaturate(I, x_(0,0));         false) else true)
+  assert(try (saturate(I, x_(0,0), Strategy => Msolve); false) else true)
+  assert(I == saturate(I, x_(0,0)))
+///

--- a/M2/Macaulay2/packages/Msolve/tests.m2
+++ b/M2/Macaulay2/packages/Msolve/tests.m2
@@ -13,3 +13,28 @@ TEST ///
   assert(try (saturate(I, x_(0,0), Strategy => Msolve); false) else true)
   assert(I == saturate(I, x_(0,0)))
 ///
+
+TEST ///
+  A = QQ[x,y,z]
+  B = A[u,v,w]
+  I = minors_2 matrix {{x,y,z}, {u,v,w}}
+  assert(I == ideal msolveGB I)
+  I = minors_2 matrix {{x,y^2,z^3}, {u^4,v^5,w^6}}
+  assert(I == ideal msolveGB I)
+///
+
+TEST ///
+  R = QQ[x,a,b,c,d]
+  f = 7*x^2+a*x+b
+  g = 2*x^2+c*x+d
+  I = eliminate(x, ideal(f,g))
+  J = msolveEliminate(x, ideal(f,g))
+  assert(sub(I, ring J) == J)
+
+  R = ZZ/11[x,a,b,c,d]
+  f = 7*x^2+a*x+b
+  g = 2*x^2+c*x+d
+  I = eliminate(x, ideal(f,g))
+  J = msolveEliminate(x, ideal(f,g))
+  assert(sub(I, ring J) == ideal selectInSubring(1, gens J))
+///

--- a/M2/Macaulay2/packages/Msolve/tests.m2
+++ b/M2/Macaulay2/packages/Msolve/tests.m2
@@ -15,10 +15,20 @@ TEST ///
 ///
 
 TEST ///
-  A = QQ[x,y,z]
+  A = ZZ/1073741827[x,y,z]
   B = A[u,v,w]
   I = minors_2 matrix {{x,y,z}, {u,v,w}}
+  -- TODO: loses homogeneity
   assert(I == ideal msolveGB I)
+  assert(I == ideal msolveSaturate(I, B_0))
+  assert(I == ideal msolveSaturate(I, B_3))
+  -- TODO: eliminate doesn't work over tower rings
+  msolveEliminate(I, B_0) -- == eliminate(I, B_0)
+  -- TODO: msolveEliminate can't eliminate variables in the base ring:
+  -- msolveEliminate(I, B_3)
+  -- TODO: msolveLeadMonomials doesn't work for tower rings yet
+  -- msolveLeadMonomials I
+  --
   I = minors_2 matrix {{x,y^2,z^3}, {u^4,v^5,w^6}}
   assert(I == ideal msolveGB I)
 ///

--- a/M2/Macaulay2/packages/TerraciniLoci.m2
+++ b/M2/Macaulay2/packages/TerraciniLoci.m2
@@ -59,7 +59,6 @@ export {
     }
 
 importFrom("Core", {"concatRows"})
-exportFrom(FastMinors, {"Threads"})
 
 terraciniLocus = method(Options => {Threads => 0})
 


### PR DESCRIPTION
This PR adds several important features that I actually use and care about and wanted to have in this package:
- allows variables like `x_(0,0)`
- allows tower rings (except for msolveLeadMonomials)
- adds msolveSaturate as a hook for saturate
- adds several tests, since there were none

It also adds some less important things like:
- disallows rings over ZZ or GF
- reduces code duplication
- checks the version of msolve using findProgram
- renames "number of threads" to Threads (moving it to Core)
- fixes several cosmetic issues in the documentation

Lastly, I fixed the unit-tests error in readMsolve. This should pass all tests.

Here's a list of all commits. I'm happy to break this down into several PRs if you'd like.
- **unified running msolve**
- **switched to using findProgram/runProgram**
- **unified default options for msolve commands**
- **exported Threads and renamed "number of threads"**
- **added cosmetic changes to documentation**
- **fixed inputOkay to disallow ZZ and GF**
- **fixed maximum prime characteristic in msolve**
- **added msolveSaturate as strategy for saturation**
- **added characteristic check for msolve bug**
- **added a test for msolveSaturate**
- **simplified msolveSaturate**
- **further cosmetic documentation changes**
- **unified ring sanitization for msolve**
- **added helper routine readMsolveList**
- **fixed an issue in monoidIndex**
- **added kludge for weird monomial order bug**
- **added more ring tower tests for msolve**
- **fixed formatting of readMsolve unit-test**